### PR TITLE
update full load command and loader

### DIFF
--- a/fec/management/commands/full_load.py
+++ b/fec/management/commands/full_load.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         if options['end']:
             end_date = options['end']
         if options['repeat-interval']:
-            repeat_interval = int(options['repeat-interval'])
+            repeat_interval = int(options['repeat-interval']) * 60
         else:
             repeat_interval = None
         if options['filing_dir']:
@@ -60,11 +60,6 @@ class Command(BaseCommand):
             else:
                 loader.download_filings(filings, filing_dir)
                 loader.load_filings(filing_dir, delete=bool(repeat_interval))
-
-            if repeat_interval:
-                time.sleep(repeat_interval)
-            else:
-                break
 
             if repeat_interval:
                 time.sleep(repeat_interval)

--- a/fec/management/commands/full_load.py
+++ b/fec/management/commands/full_load.py
@@ -33,11 +33,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         fec_time=pytz.timezone('US/Eastern') #fec time is eastern
 
-        unparsed_start = datetime.datetime.now(fec_time) - datetime.timedelta(days=2)
-        start_date = unparsed_start.strftime('%Y%m%d')
-        unparsed_end = datetime.datetime.now(fec_time) + datetime.timedelta(days=1)
-        end_date = unparsed_end.strftime('%Y%m%d')
-
         if options['start']:
             start_date = options['start']
         if options['end']:
@@ -52,14 +47,26 @@ class Command(BaseCommand):
             filing_dir = 'filings/'
 
         while True:
-            print("looking for filings for period {}-{}".format(start_date, end_date))
-            #keep looping if an interval is provided, this is mostly for testing
-            filings = loader.get_filing_list(start_date, end_date)
-            if not filings:
-                print("failed to find any filings for period {}-{}".format(start_date, end_date))
-            else:
-                loader.download_filings(filings, filing_dir)
-                loader.load_filings(filing_dir, delete=bool(repeat_interval))
+            
+            if not options['start']:
+                unparsed_start = datetime.datetime.now(fec_time) - datetime.timedelta(days=2)
+                start_date = unparsed_start.strftime('%Y%m%d')
+            
+            if not options['end']:
+                unparsed_end = datetime.datetime.now(fec_time) + datetime.timedelta(days=1)
+                end_date = unparsed_end.strftime('%Y%m%d')
+            
+            try:
+                print("looking for filings for period {}-{}".format(start_date, end_date))
+                #keep looping if an interval is provided, this is mostly for testing
+                filings = loader.get_filing_list(start_date, end_date)
+                if not filings:
+                    print("failed to find any filings for period {}-{}".format(start_date, end_date))
+                else:
+                    loader.download_filings(filings, filing_dir)
+                    loader.load_filings(filing_dir, delete=bool(repeat_interval))
+            except Exception as e:
+                traceback.print_exc()
 
             if repeat_interval:
                 time.sleep(repeat_interval)

--- a/fec/management/commands/full_load.py
+++ b/fec/management/commands/full_load.py
@@ -57,9 +57,9 @@ class Command(BaseCommand):
             filings = loader.get_filing_list(start_date, end_date)
             if not filings:
                 print("failed to find any filings for period {}-{}".format(start_date, end_date))
-            
-            loader.download_filings(filings, filing_dir)
-            loader.load_filings(filing_dir)
+            else:
+                loader.download_filings(filings, filing_dir)
+                loader.load_filings(filing_dir, delete=bool(repeat_interval))
 
             if repeat_interval:
                 time.sleep(repeat_interval)

--- a/fec/utils/loader.py
+++ b/fec/utils/loader.py
@@ -50,6 +50,15 @@ def get_filing_list(start_date, end_date, max_fails=10, waittime=10):
                     tags=["nyt-fec", "result:fail"])
                 return None
             time.sleep(waittime)
+
+        if 'error' in files:
+            code = files['error']['code']
+            message = files['error']['message']
+            logging.log(title="FEC download failed",
+                    text=f'{code}. {message}',
+                    tags=["nyt-fec", "result:fail"])
+            return None
+
         try:
             results = files['results']
         except KeyError:
@@ -557,7 +566,7 @@ def create_or_update_filing_status(filing_id, status):
         fs.save()    
 
 
-def load_filings(filing_dir):
+def load_filings(filing_dir, delete=False):
 
     
     filing_fieldnames = [f.name for f in Filing._meta.get_fields()]
@@ -589,6 +598,9 @@ def load_filings(filing_dir):
             logging.log(title="Filing {} loaded".format(filing_id),
                     text='filing {} successfully loaded'.format(filing_id),
                     tags=["nyt-fec", "result:success"])
+
+            if delete:
+                os.remove(full_filename)
 
             filings_loaded += 1
 


### PR DESCRIPTION
- handle errors in fec download response. fec returns two different error formats unfortunately
- add flag to optionally delete filings after loading
  - auto enable delete when `repeat_interval` exists (assumes running on a server/container that might fill up)
- convert repeat_interval from seconds to minutes
- prevent waiting repeat_interval twice
- add try except on full_load to run forever
- recalc start_date and end_date within the while loop for full_load if running over multiple days