### PR TITLE
add workdir to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN pip install -r /usr/src/app/requirements.txt
 COPY . /usr/src/app/
 
 ENV PYTHONPATH=/usr/src/app
-
-
+WORKDIR /usr/src/app
 
 EXPOSE 80
 CMD ["/usr/local/bin/uwsgi", "--ini", "/usr/src/app/config/prd/docker.ini"]


### PR DESCRIPTION
this makes some things easier like not having to provide the `filings_dir` or mirroring some settings in local and prod like PYTHONPATH=. etc.